### PR TITLE
fix: update query order in Azure DevOps API calls and sort builds by …

### DIFF
--- a/api/AzDevOpsApi.Tests/Services/AzureDevOpsServicesTests.cs
+++ b/api/AzDevOpsApi.Tests/Services/AzureDevOpsServicesTests.cs
@@ -513,7 +513,7 @@ public class AzureDevOpsServicesTests : IDisposable
             .WithParam("$top", count.ToString())
             .WithParam("api-version", "7.1")
             .WithParam("statusFilter", "all")
-            .WithParam("queryOrder", "startTimeDescending");
+            .WithParam("queryOrder", "queueTimeDescending");
         _wireMockServer
             .Given(request.UsingGet())
             .RespondWith(Response.Create()
@@ -735,7 +735,7 @@ public class AzureDevOpsServicesTests : IDisposable
                 .WithParam("$top", "10")
                 .WithParam("reasonFilter", "individualCI")
                 .WithParam("api-version", "7.1")
-                .WithParam("queryOrder", "startTimeDescending")
+                .WithParam("queryOrder", "queueTimeDescending")
                 .UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
@@ -960,7 +960,7 @@ public class AzureDevOpsServicesTests : IDisposable
                 .WithParam("$top", "10")
                 .WithParam("reasonFilter", "individualCI")
                 .WithParam("api-version", "7.1")
-                .WithParam("queryOrder", "startTimeDescending")
+                .WithParam("queryOrder", "queueTimeDescending")
                 .UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
@@ -988,7 +988,7 @@ public class AzureDevOpsServicesTests : IDisposable
                 .WithParam("$top", "10")
                 .WithParam("reasonFilter", "individualCI")
                 .WithParam("api-version", "7.1")
-                .WithParam("queryOrder", "startTimeDescending")
+                .WithParam("queryOrder", "queueTimeDescending")
                 .UsingGet())
             .RespondWith(Response.Create()
                 .WithStatusCode(200)
@@ -1014,7 +1014,7 @@ public class AzureDevOpsServicesTests : IDisposable
             .WithParam("$top", count.ToString())
             .WithParam("api-version", "7.1")
             .WithParam("statusFilter", "all")
-            .WithParam("queryOrder", "startTimeDescending");
+            .WithParam("queryOrder", "queueTimeDescending");
         _wireMockServer
             .Given(request.UsingGet())
             .RespondWith(Response.Create()

--- a/api/AzDevOpsApi/Services/AzureDevOpsService.cs
+++ b/api/AzDevOpsApi/Services/AzureDevOpsService.cs
@@ -98,7 +98,7 @@ namespace AzDevOpsApi.Services
         {
             try
             {
-                var url = $"{_baseUrl.TrimEnd('/')}/{organization}/{project}/_apis/build/builds?definitions={pipelineId}&$top={count}&statusFilter={statusFilter}&queryOrder=startTimeDescending&api-version=7.1";
+                var url = $"{_baseUrl.TrimEnd('/')}/{organization}/{project}/_apis/build/builds?definitions={pipelineId}&$top={count}&statusFilter={statusFilter}&queryOrder=queueTimeDescending&api-version=7.1";
                 if (!string.IsNullOrEmpty(branch))
                 {
                     url += $"&branchName={Uri.EscapeDataString(branch)}";
@@ -146,7 +146,7 @@ namespace AzDevOpsApi.Services
                 var branch = "refs/heads/main"; // Default branch, can be parameterized if needed
                 var count = 10; // Number of builds to check, can be parameterized if needed
                 var reasonFilter = "individualCI"; // Filter for individual CI builds
-                var url = $"{_baseUrl.TrimEnd('/')}/{organization}/{project}/_apis/build/builds?definitions={pipelineId}&branchName={branch}&$top={count}&reasonFilter={reasonFilter}&api-version=7.1&queryOrder=startTimeDescending";
+                var url = $"{_baseUrl.TrimEnd('/')}/{organization}/{project}/_apis/build/builds?definitions={pipelineId}&branchName={branch}&$top={count}&reasonFilter={reasonFilter}&api-version=7.1&queryOrder=queueTimeDescending";
                 var response = await GetAsync<AzureDevOpsBuildsResponse>(url, pat);
 
                 _logger.LogInformation("Retrieved {Count} builds for pipeline {PipelineId}", response.Value.Length, pipelineId);

--- a/client/src/components/BuildsView.tsx
+++ b/client/src/components/BuildsView.tsx
@@ -419,7 +419,9 @@ const BuildsView: React.FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {builds.map((build) => {
+                {[...builds]
+                  .sort((a, b) => b.buildNumber.localeCompare(a.buildNumber, undefined, { numeric: true, sensitivity: 'base' }))
+                  .map((build) => {
                   const projectName = build.project?.name || selectedProject;
                   const orgName = organization;
                   const buildUrl = `https://dev.azure.com/${encodeURIComponent(orgName)}/${encodeURIComponent(projectName)}/_build/results?buildId=${build.id}&view=results`;


### PR DESCRIPTION
…build number in BuildsView